### PR TITLE
Do not update Okta-AWSCLI configuration 

### DIFF
--- a/oktaawscli/aws_auth.py
+++ b/oktaawscli/aws_auth.py
@@ -11,17 +11,16 @@ import boto3
 from botocore.exceptions import ClientError
 
 
-
 class AwsPartition(Enum):
-    AWS = 1 
+    AWS = 1
     AWS_US_GOV = 2
 
 
-class AwsAuth():
+class AwsAuth:
     """ Methods to support AWS authentication using STS """
 
     def __init__(self, profile, okta_profile, lookup, verbose, logger):
-        home_dir = os.path.expanduser('~')
+        home_dir = os.path.expanduser("~")
         self.creds_dir = home_dir + "/.aws"
         self.creds_file = self.creds_dir + "/credentials"
         self.lookup = lookup
@@ -31,20 +30,19 @@ class AwsAuth():
         self.role = ""
         self.aws_partition = AwsPartition.AWS
 
-        okta_config = home_dir + '/.okta-aws'
+        okta_config = home_dir + "/.okta-aws"
         parser = RawConfigParser()
         parser.read(okta_config)
 
-        if parser.has_option(okta_profile, 'role'):
-            self.role = parser.get(okta_profile, 'role')
+        if parser.has_option(okta_profile, "role"):
+            self.role = parser.get(okta_profile, "role")
             self.logger.debug("Setting AWS role to %s" % self.role)
             self.aws_partition = self.__find_aws_partition_from_role_arn(self.role)
             self.logger.debug("Setting AWS partition to %s" % self.aws_partition)
 
-        if parser.has_option(okta_profile, 'profile') and not profile:
-            self.profile = parser.get(okta_profile, 'profile')
+        if parser.has_option(okta_profile, "profile") and not profile:
+            self.profile = parser.get(okta_profile, "profile")
             self.logger.debug("Setting AWS profile to %s" % self.profile)
-
 
     def choose_aws_role(self, assertion, refresh_role):
         """ Choose AWS role from SAML assertion """
@@ -58,15 +56,18 @@ class AwsAuth():
             elif refresh_role:
                 self.logger.info("""Refreshing role""")
             else:
-                self.logger.info("""Predefined role, %s, not found in the list
-of roles assigned to you.""" % self.role)
+                self.logger.info(
+                    """Predefined role, %s, not found in the list
+of roles assigned to you."""
+                    % self.role
+                )
 
         self.logger.info("Please choose a role.")
         role_options = self.__create_options_from(roles, assertion, self.lookup)
         for option in role_options:
             print(option)
 
-        role_choice = int(input('Please select the AWS role: ')) - 1
+        role_choice = int(input("Please select the AWS role: ")) - 1
         return roles[role_choice]
 
     @staticmethod
@@ -77,26 +78,28 @@ of roles assigned to you.""" % self.role)
         aws_partition = AwsAuth.__find_aws_partition_from_role_arn(principal_arn)
         logger.debug("Getting STS token against ARN partition: %s" % aws_partition)
         if aws_partition == AwsPartition.AWS_US_GOV:
-            sts = boto3.client('sts', region_name='us-gov-west-1')
+            sts = boto3.client("sts", region_name="us-gov-west-1")
         else:
-            sts = boto3.client('sts')
+            sts = boto3.client("sts")
 
         try:
-            response = sts.assume_role_with_saml(RoleArn=role_arn,
-                                                 PrincipalArn=principal_arn,
-                                                 SAMLAssertion=assertion,
-                                                 DurationSeconds=duration or 3600)
+            response = sts.assume_role_with_saml(
+                RoleArn=role_arn,
+                PrincipalArn=principal_arn,
+                SAMLAssertion=assertion,
+                DurationSeconds=duration or 3600,
+            )
         except ClientError as ex:
             if logger:
                 logger.error(
-                    "Could not retrieve credentials: %s" %
-                    ex.response['Error']['Message']
+                    "Could not retrieve credentials: %s"
+                    % ex.response["Error"]["Message"]
                 )
                 sys.exit(-1)
             else:
                 raise
 
-        credentials = response['Credentials']
+        credentials = response["Credentials"]
         return credentials
 
     def check_sts_token(self, profile):
@@ -117,27 +120,35 @@ of roles assigned to you.""" % self.role)
             return False
 
         elif not parser.has_section(self.profile):
-            self.logger.info("No existing credentials found. Requesting new credentials.")
+            self.logger.info(
+                "No existing credentials found. Requesting new credentials."
+            )
             return False
 
-        self.logger.debug("Checking STS token against ARN partition: %s" % self.aws_partition)
+        self.logger.debug(
+            "Checking STS token against ARN partition: %s" % self.aws_partition
+        )
         if self.aws_partition == AwsPartition.AWS_US_GOV:
-            session = boto3.Session(profile_name=profile, region_name='us-gov-west-1')
+            session = boto3.Session(profile_name=profile, region_name="us-gov-west-1")
         else:
             session = boto3.Session(profile_name=profile)
 
-        sts = session.client('sts')
+        sts = session.client("sts")
         try:
             sts.get_caller_identity()
 
         except ClientError as ex:
-            if ex.response['Error']['Code'] == 'ExpiredToken':
-                self.logger.info("Temporary credentials have expired. Requesting new credentials.")
-            elif ex.response['Error']['Code'] == 'InvalidClientTokenId':
+            if ex.response["Error"]["Code"] == "ExpiredToken":
+                self.logger.info(
+                    "Temporary credentials have expired. Requesting new credentials."
+                )
+            elif ex.response["Error"]["Code"] == "InvalidClientTokenId":
                 self.logger.info("Credential is invalid. Requesting new credentials.")
             else:
                 # See https://docs.aws.amazon.com/STS/latest/APIReference/CommonErrors.html
-                self.logger.info("An unhandled error occurred. Requesting new credentials.")
+                self.logger.info(
+                    "An unhandled error occurred. Requesting new credentials."
+                )
 
             return False
 
@@ -156,27 +167,31 @@ of roles assigned to you.""" % self.role)
         if not config.has_section(self.profile):
             config.add_section(self.profile)
 
-        config.set(self.profile, 'aws_access_key_id', access_key_id)
-        config.set(self.profile, 'aws_secret_access_key', secret_access_key)
-        config.set(self.profile, 'aws_session_token', session_token)
+        config.set(self.profile, "aws_access_key_id", access_key_id)
+        config.set(self.profile, "aws_secret_access_key", secret_access_key)
+        config.set(self.profile, "aws_session_token", session_token)
 
-        with open(self.creds_file, 'w+') as configfile:
+        with open(self.creds_file, "w+") as configfile:
             config.write(configfile)
         self.logger.info("Temporary credentials written to profile: %s" % self.profile)
-        self.logger.info("Invoke using: aws --profile %s <service> <command>" % self.profile)
+        self.logger.info(
+            "Invoke using: aws --profile %s <service> <command>" % self.profile
+        )
 
     @staticmethod
     def __extract_available_roles_from(assertion):
-        aws_attribute_role = 'https://aws.amazon.com/SAML/Attributes/Role'
-        attribute_value_urn = '{urn:oasis:names:tc:SAML:2.0:assertion}AttributeValue'
+        aws_attribute_role = "https://aws.amazon.com/SAML/Attributes/Role"
+        attribute_value_urn = "{urn:oasis:names:tc:SAML:2.0:assertion}AttributeValue"
         roles = []
         role_tuple = namedtuple("RoleTuple", ["principal_arn", "role_arn"])
         root = ET.fromstring(base64.b64decode(assertion))
-        for saml2attribute in root.iter('{urn:oasis:names:tc:SAML:2.0:assertion}Attribute'):
-            if saml2attribute.get('Name') == aws_attribute_role:
+        for saml2attribute in root.iter(
+            "{urn:oasis:names:tc:SAML:2.0:assertion}Attribute"
+        ):
+            if saml2attribute.get("Name") == aws_attribute_role:
                 for saml2attributevalue in saml2attribute.iter(attribute_value_urn):
-                    result_set = saml2attributevalue.text.split(',')
-                    if result_set[0].split(':')[5].startswith('role/'):
+                    result_set = saml2attributevalue.text.split(",")
+                    if result_set[0].split(":")[5].startswith("role/"):
                         roles.append(role_tuple(*reversed(result_set)))
                     else:
                         roles.append(role_tuple(*result_set))
@@ -187,25 +202,35 @@ of roles assigned to you.""" % self.role)
 
         # convert all account IDs to an account alias, if an account alias has been resolved do not perform an additional lookup
         for role in roles:
-            account_id = role.role_arn.split(':')[4]
-            rolename = role.role_arn.split(':')[5]
+            account_id = role.role_arn.split(":")[4]
+            rolename = role.role_arn.split(":")[5]
 
             if lookup and account_id not in alias_db:
                 self.logger.debug("Performing AWS account alias lookup")
-                creds = AwsAuth.get_sts_token(role.role_arn, role.principal_arn, assertion, duration=900, logger=self.logger)
-                access_key_id = creds['AccessKeyId']
-                secret_access_key = creds['SecretAccessKey']
-                session_token = creds['SessionToken']
+                creds = AwsAuth.get_sts_token(
+                    role.role_arn,
+                    role.principal_arn,
+                    assertion,
+                    duration=900,
+                    logger=self.logger,
+                )
+                access_key_id = creds["AccessKeyId"]
+                secret_access_key = creds["SecretAccessKey"]
+                session_token = creds["SessionToken"]
 
-                arn_region = role.principal_arn.split(':')[1]
-                iam_region = 'us-gov-west-1' if arn_region == 'aws-us-gov' else 'us-east-1'
-                client = boto3.client('iam',
-                                      region_name = iam_region,
-                                      aws_access_key_id = access_key_id,
-                                      aws_secret_access_key = secret_access_key,
-                                      aws_session_token = session_token)
+                arn_region = role.principal_arn.split(":")[1]
+                iam_region = (
+                    "us-gov-west-1" if arn_region == "aws-us-gov" else "us-east-1"
+                )
+                client = boto3.client(
+                    "iam",
+                    region_name=iam_region,
+                    aws_access_key_id=access_key_id,
+                    aws_secret_access_key=secret_access_key,
+                    aws_session_token=session_token,
+                )
                 try:
-                    alias = client.list_account_aliases()['AccountAliases'][0]
+                    alias = client.list_account_aliases()["AccountAliases"][0]
                     alias_db[account_id] = alias
                 except Exception as ex:
                     self.logger.warning("Unable to perform alias lookup: %s" % ex)
@@ -213,29 +238,32 @@ of roles assigned to you.""" % self.role)
         # store the roles and their aliases for sorting
         options = []
         for role in roles:
-            account_id = role.role_arn.split(':')[4]
-            rolename = role.role_arn.split(':')[5]
+            account_id = role.role_arn.split(":")[4]
+            rolename = role.role_arn.split(":")[5]
 
             if account_id not in alias_db:
                 alias_db[account_id] = account_id
 
-            options.append ({'alias': alias_db[account_id], 'role': rolename})
-        options.sort (key = lambda o: o['alias']+o['role'])
+            options.append({"alias": alias_db[account_id], "role": rolename})
+        options.sort(key=lambda o: o["alias"] + o["role"])
 
         # convert the role list to a list of strings
         option_set = []
         option_index = 1
         for option in options:
-            option_set.append ('{ndex}: {alias} - {role}'.format (ndex=option_index, alias = option['alias'], role = option['role']))
+            option_set.append(
+                "{ndex}: {alias} - {role}".format(
+                    ndex=option_index, alias=option["alias"], role=option["role"]
+                )
+            )
             option_index += 1
 
         return option_set
 
-
     @staticmethod
     def __find_aws_partition_from_role_arn(role_arn):
-        arn_aws_partition = role_arn.split(':')[1]
-        if arn_aws_partition == 'aws-us-gov':
+        arn_aws_partition = role_arn.split(":")[1]
+        if arn_aws_partition == "aws-us-gov":
             return AwsPartition.AWS_US_GOV
         else:
             return AwsPartition.AWS

--- a/oktaawscli/aws_auth.py
+++ b/oktaawscli/aws_auth.py
@@ -191,7 +191,6 @@ of roles assigned to you.""" % self.role)
             rolename = role.role_arn.split(':')[5]
 
             if lookup and account_id not in alias_db:
-                print ("Looking up alias for {}".format (account_id))
                 self.logger.debug("Performing AWS account alias lookup")
                 creds = AwsAuth.get_sts_token(role.role_arn, role.principal_arn, assertion, duration=900, logger=self.logger)
                 access_key_id = creds['AccessKeyId']

--- a/oktaawscli/aws_auth.py
+++ b/oktaawscli/aws_auth.py
@@ -11,6 +11,7 @@ import boto3
 from botocore.exceptions import ClientError
 
 
+
 class AwsPartition(Enum):
     AWS = 1 
     AWS_US_GOV = 2
@@ -182,17 +183,23 @@ of roles assigned to you.""" % self.role)
         return roles
 
     def __create_options_from(self, roles, assertion, lookup=False):
-        options = []
-        for index, role in enumerate(roles):
-            if lookup:
+        alias_db = {}
+
+        # convert all account IDs to an account alias, if an account alias has been resolved do not perform an additional lookup
+        for role in roles:
+            account_id = role.role_arn.split(':')[4]
+            rolename = role.role_arn.split(':')[5]
+
+            if lookup and account_id not in alias_db:
+                print ("Looking up alias for {}".format (account_id))
                 self.logger.debug("Performing AWS account alias lookup")
                 creds = AwsAuth.get_sts_token(role.role_arn, role.principal_arn, assertion, duration=900, logger=self.logger)
                 access_key_id = creds['AccessKeyId']
                 secret_access_key = creds['SecretAccessKey']
                 session_token = creds['SessionToken']
+
                 arn_region = role.principal_arn.split(':')[1]
                 iam_region = 'us-gov-west-1' if arn_region == 'aws-us-gov' else 'us-east-1'
-
                 client = boto3.client('iam',
                                       region_name = iam_region,
                                       aws_access_key_id = access_key_id,
@@ -200,19 +207,31 @@ of roles assigned to you.""" % self.role)
                                       aws_session_token = session_token)
                 try:
                     alias = client.list_account_aliases()['AccountAliases'][0]
-                    rolename = role.role_arn.split(':')[5]
-                    option = '{i}: {accname} - {rolename}'.format(i=index+1,
-                                                                  accname = alias,
-                                                                  rolename = rolename)
+                    alias_db[account_id] = alias
                 except Exception as ex:
                     self.logger.warning("Unable to perform alias lookup: %s" % ex)
-                    option = '{i}: {rolearn}'.format(i=index+1,
-                                                     rolearn = role.role_arn)
-                    pass
-                options.append(option)
-            else:
-                options.append("%d: %s" % (index + 1, role.role_arn))
-        return options
+
+        # store the roles and their aliases for sorting
+        options = []
+        for role in roles:
+            account_id = role.role_arn.split(':')[4]
+            rolename = role.role_arn.split(':')[5]
+
+            if account_id not in alias_db:
+                alias_db[account_id] = account_id
+
+            options.append ({'alias': alias_db[account_id], 'role': rolename})
+        options.sort (key = lambda o: o['alias']+o['role'])
+
+        # convert the role list to a list of strings
+        option_set = []
+        option_index = 1
+        for option in options:
+            option_set.append ('{ndex}: {alias} - {role}'.format (ndex=option_index, alias = option['alias'], role = option['role']))
+            option_index += 1
+
+        return option_set
+
 
     @staticmethod
     def __find_aws_partition_from_role_arn(role_arn):

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -12,7 +12,7 @@ from oktaawscli.aws_auth import AwsAuth
 
 def get_credentials(aws_auth, okta_profile, profile,
                     verbose, logger, totp_token, cache, refresh_role, 
-                    okta_username=None, okta_password=None):
+                    okta_username=None, okta_password=None, noupdate=False):
     """ Gets credentials from Okta """
 
     okta_auth_config = OktaAuthConfig(logger)
@@ -24,7 +24,8 @@ def get_credentials(aws_auth, okta_profile, profile,
     role = aws_auth.choose_aws_role(assertion, refresh_role)
     principal_arn, role_arn = role
 
-    okta_auth_config.write_role_to_profile(okta_profile, role_arn)
+    if not noupdate:
+        okta_auth_config.write_role_to_profile(okta_profile, role_arn)
     duration = okta_auth_config.duration_for(okta_profile)
 
     sts_token = aws_auth.get_sts_token(
@@ -84,6 +85,7 @@ created. If omitted, credentials will output to console.\n")
 to ~/.okta-credentials.cache\n')
 @click.option('-t', '--token', help='TOTP token from your authenticator app')
 @click.option('-l', '--lookup', is_flag=True, help='Look up AWS account names')
+@click.option('-n', '--noupdate', is_flag=True, help='Do not update ~/.okta_aws with your selected role')
 @click.option('-U', '--username', 'okta_username', help="Okta username")
 @click.option('-P', '--password', 'okta_password', help="Okta password")
 @click.argument('awscli_args', nargs=-1, type=click.UNPROCESSED)
@@ -118,7 +120,7 @@ def main(okta_profile, profile, verbose, version,
                 getting new credentials anyway.")
         refresh_role = True if force else False
         get_credentials(
-            aws_auth, okta_profile, profile, verbose, logger, token, cache, refresh_role, okta_username, okta_password
+            aws_auth, okta_profile, profile, verbose, logger, token, cache, refresh_role, okta_username, okta_password, noupdate
         )
 
     if awscli_args:

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -12,7 +12,7 @@ from oktaawscli.aws_auth import AwsAuth
 
 def get_credentials(aws_auth, okta_profile, profile,
                     verbose, logger, totp_token, cache, refresh_role, 
-                    okta_username=None, okta_password=None, noupdate=False):
+                    okta_username=None, okta_password=None, noupdate=False, print_env=False):
     """ Gets credentials from Okta """
 
     okta_auth_config = OktaAuthConfig(logger)
@@ -50,6 +50,9 @@ def get_credentials(aws_auth, okta_profile, profile,
             cache.close()
         sys.exit(0)
     else:
+        if print_env:
+            console_output(access_key_id, secret_access_key, session_token, verbose)
+
         aws_auth.write_sts_token(access_key_id,
                                  secret_access_key, session_token)
 
@@ -74,6 +77,7 @@ def console_output(access_key_id, secret_access_key, session_token, verbose):
 @click.option('-V', '--version', is_flag=True,
               help='Outputs version number and sys.exits')
 @click.option('-d', '--debug', is_flag=True, help='Enables debug mode')
+@click.option('-e', '--env', is_flag=True, help='Print environment variable information to STDOUT')
 @click.option('-f', '--force', is_flag=True, help='Forces new STS credentials. \
 Skips STS credentials validation.')
 @click.option('--okta-profile', help="Name of the profile to use in .okta-aws. \
@@ -91,7 +95,7 @@ to ~/.okta-credentials.cache\n')
 @click.argument('awscli_args', nargs=-1, type=click.UNPROCESSED)
 def main(okta_profile, profile, verbose, version,
          debug, force, cache, lookup, awscli_args, 
-         token, okta_username, okta_password, noupdate):
+         token, okta_username, okta_password, noupdate, env):
     """ Authenticate to awscli using Okta """
     if version:
         print(__version__)
@@ -120,7 +124,7 @@ def main(okta_profile, profile, verbose, version,
                 getting new credentials anyway.")
         refresh_role = True if force else False
         get_credentials(
-            aws_auth, okta_profile, profile, verbose, logger, token, cache, refresh_role, okta_username, okta_password, noupdate
+            aws_auth, okta_profile, profile, verbose, logger, token, cache, refresh_role, okta_username, okta_password, noupdate, print_env=env
         )
 
     if awscli_args:

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -91,7 +91,7 @@ to ~/.okta-credentials.cache\n')
 @click.argument('awscli_args', nargs=-1, type=click.UNPROCESSED)
 def main(okta_profile, profile, verbose, version,
          debug, force, cache, lookup, awscli_args, 
-         token, okta_username, okta_password):
+         token, okta_username, okta_password, noupdate):
     """ Authenticate to awscli using Okta """
     if version:
         print(__version__)

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -10,15 +10,33 @@ from oktaawscli.okta_auth import OktaAuth
 from oktaawscli.okta_auth_config import OktaAuthConfig
 from oktaawscli.aws_auth import AwsAuth
 
-def get_credentials(aws_auth, okta_profile, profile,
-                    verbose, logger, totp_token, cache, refresh_role, 
-                    okta_username=None, okta_password=None, noupdate=False, print_env=False):
+
+def get_credentials(
+    aws_auth,
+    okta_profile,
+    profile,
+    verbose,
+    logger,
+    totp_token,
+    cache,
+    refresh_role,
+    okta_username=None,
+    okta_password=None,
+    noupdate=False,
+    print_env=False,
+):
     """ Gets credentials from Okta """
 
     okta_auth_config = OktaAuthConfig(logger)
-    okta = OktaAuth(okta_profile, verbose, logger, totp_token, 
-        okta_auth_config, okta_username, okta_password)
-
+    okta = OktaAuth(
+        okta_profile,
+        verbose,
+        logger,
+        totp_token,
+        okta_auth_config,
+        okta_username,
+        okta_password,
+    )
 
     _, assertion = okta.get_assertion()
     role = aws_auth.choose_aws_role(assertion, refresh_role)
@@ -29,23 +47,19 @@ def get_credentials(aws_auth, okta_profile, profile,
     duration = okta_auth_config.duration_for(okta_profile)
 
     sts_token = aws_auth.get_sts_token(
-        role_arn,
-        principal_arn,
-        assertion,
-        duration=duration,
-        logger=logger
+        role_arn, principal_arn, assertion, duration=duration, logger=logger
     )
-    access_key_id = sts_token['AccessKeyId']
-    secret_access_key = sts_token['SecretAccessKey']
-    session_token = sts_token['SessionToken']
-    session_token_expiry = sts_token['Expiration']
+    access_key_id = sts_token["AccessKeyId"]
+    secret_access_key = sts_token["SecretAccessKey"]
+    session_token = sts_token["SessionToken"]
+    session_token_expiry = sts_token["Expiration"]
     logger.info("Session token expires on: %s" % session_token_expiry)
     if not aws_auth.profile:
-        exports = console_output(access_key_id, secret_access_key,
-                                 session_token, verbose)
+        exports = console_output(
+            access_key_id, secret_access_key, session_token, verbose
+        )
         if cache:
-            cache = open("%s/.okta-credentials.cache" %
-                         (os.path.expanduser('~'),), 'w')
+            cache = open("%s/.okta-credentials.cache" % (os.path.expanduser("~"),), "w")
             cache.write(exports)
             cache.close()
         sys.exit(0)
@@ -53,19 +67,20 @@ def get_credentials(aws_auth, okta_profile, profile,
         if print_env:
             console_output(access_key_id, secret_access_key, session_token, verbose)
 
-        aws_auth.write_sts_token(access_key_id,
-                                 secret_access_key, session_token)
+        aws_auth.write_sts_token(access_key_id, secret_access_key, session_token)
 
 
 def console_output(access_key_id, secret_access_key, session_token, verbose):
     """ Outputs STS credentials to console """
     if verbose:
         print("Use these to set your environment variables:")
-    exports = "\n".join([
-        "export AWS_ACCESS_KEY_ID=%s" % access_key_id,
-        "export AWS_SECRET_ACCESS_KEY=%s" % secret_access_key,
-        "export AWS_SESSION_TOKEN=%s" % session_token
-    ])
+    exports = "\n".join(
+        [
+            "export AWS_ACCESS_KEY_ID=%s" % access_key_id,
+            "export AWS_SECRET_ACCESS_KEY=%s" % secret_access_key,
+            "export AWS_SESSION_TOKEN=%s" % session_token,
+        ]
+    )
     print(exports)
 
     return exports
@@ -73,39 +88,76 @@ def console_output(access_key_id, secret_access_key, session_token, verbose):
 
 # pylint: disable=R0913
 @click.command()
-@click.option('-v', '--verbose', is_flag=True, help='Enables verbose mode')
-@click.option('-V', '--version', is_flag=True,
-              help='Outputs version number and sys.exits')
-@click.option('-d', '--debug', is_flag=True, help='Enables debug mode')
-@click.option('-e', '--env', is_flag=True, help='Print environment variable information to STDOUT')
-@click.option('-f', '--force', is_flag=True, help='Forces new STS credentials. \
-Skips STS credentials validation.')
-@click.option('--okta-profile', help="Name of the profile to use in .okta-aws. \
-If none is provided, then the default profile will be used.\n")
-@click.option('--profile', help="Name of the profile to store temporary \
+@click.option("-v", "--verbose", is_flag=True, help="Enables verbose mode")
+@click.option(
+    "-V", "--version", is_flag=True, help="Outputs version number and sys.exits"
+)
+@click.option("-d", "--debug", is_flag=True, help="Enables debug mode")
+@click.option(
+    "-e", "--env", is_flag=True, help="Print environment variable information to STDOUT"
+)
+@click.option(
+    "-f",
+    "--force",
+    is_flag=True,
+    help="Forces new STS credentials. \
+Skips STS credentials validation.",
+)
+@click.option(
+    "--okta-profile",
+    help="Name of the profile to use in .okta-aws. \
+If none is provided, then the default profile will be used.\n",
+)
+@click.option(
+    "--profile",
+    help="Name of the profile to store temporary \
 credentials in ~/.aws/credentials. If profile doesn't exist, it will be \
-created. If omitted, credentials will output to console.\n")
-@click.option('-c', '--cache', is_flag=True, help='Cache the default profile credentials \
-to ~/.okta-credentials.cache\n')
-@click.option('-t', '--token', help='TOTP token from your authenticator app')
-@click.option('-l', '--lookup', is_flag=True, help='Look up AWS account names')
-@click.option('-n', '--noupdate', is_flag=True, help='Do not update ~/.okta_aws with your selected role')
-@click.option('-U', '--username', 'okta_username', help="Okta username")
-@click.option('-P', '--password', 'okta_password', help="Okta password")
-@click.argument('awscli_args', nargs=-1, type=click.UNPROCESSED)
-def main(okta_profile, profile, verbose, version,
-         debug, force, cache, lookup, awscli_args, 
-         token, okta_username, okta_password, noupdate, env):
+created. If omitted, credentials will output to console.\n",
+)
+@click.option(
+    "-c",
+    "--cache",
+    is_flag=True,
+    help="Cache the default profile credentials \
+to ~/.okta-credentials.cache\n",
+)
+@click.option("-t", "--token", help="TOTP token from your authenticator app")
+@click.option("-l", "--lookup", is_flag=True, help="Look up AWS account names")
+@click.option(
+    "-n",
+    "--noupdate",
+    is_flag=True,
+    help="Do not update ~/.okta_aws with your selected role",
+)
+@click.option("-U", "--username", "okta_username", help="Okta username")
+@click.option("-P", "--password", "okta_password", help="Okta password")
+@click.argument("awscli_args", nargs=-1, type=click.UNPROCESSED)
+def main(
+    okta_profile,
+    profile,
+    verbose,
+    version,
+    debug,
+    force,
+    cache,
+    lookup,
+    awscli_args,
+    token,
+    okta_username,
+    okta_password,
+    noupdate,
+    env,
+):
     """ Authenticate to awscli using Okta """
     if version:
         print(__version__)
         sys.exit(0)
     # Set up logging
-    logger = logging.getLogger('okta-awscli')
+    logger = logging.getLogger("okta-awscli")
     logger.setLevel(logging.DEBUG)
     handler = logging.StreamHandler()
     handler.setLevel(logging.WARN)
-    formatter = logging.Formatter('%(levelname)s - %(message)s')
+    formatter = logging.Formatter("%(levelname)s - %(message)s")
     handler.setFormatter(formatter)
     if verbose:
         handler.setLevel(logging.INFO)
@@ -120,16 +172,29 @@ def main(okta_profile, profile, verbose, version,
     if not aws_auth.check_sts_token(profile) or force:
         if force and profile:
 
-            logger.info("Force option selected, \
-                getting new credentials anyway.")
+            logger.info(
+                "Force option selected, \
+                getting new credentials anyway."
+            )
         refresh_role = True if force else False
         get_credentials(
-            aws_auth, okta_profile, profile, verbose, logger, token, cache, refresh_role, okta_username, okta_password, noupdate, print_env=env
+            aws_auth,
+            okta_profile,
+            profile,
+            verbose,
+            logger,
+            token,
+            cache,
+            refresh_role,
+            okta_username,
+            okta_password,
+            noupdate,
+            print_env=env,
         )
 
     if awscli_args:
-        cmdline = ['aws', '--profile', profile] + list(awscli_args)
-        logger.info('Invoking: %s', ' '.join(cmdline))
+        cmdline = ["aws", "--profile", profile] + list(awscli_args)
+        logger.info("Invoking: %s", " ".join(cmdline))
         call(cmdline)
 
 

--- a/oktaawscli/version.py
+++ b/oktaawscli/version.py
@@ -1,2 +1,2 @@
 """ version string """
-__version__ = '0.4.7'
+__version__ = '0.4.8'

--- a/oktaawscli/version.py
+++ b/oktaawscli/version.py
@@ -1,2 +1,2 @@
 """ version string """
-__version__ = '0.4.6'
+__version__ = '0.4.7'


### PR DESCRIPTION
The default behavior of Okta-AWSCLI is to update the configuration file with a user's chosen role.  In this way when they choose a new profile:

`okta-awscli --profile new-profile` 

the role from the previous session is re-used.  This may not be desired if someone is using Okta-AWSCLI to work with multiple accounts simultaneously.

This patch adds 2 new options, the first is a `noupdate` CLI option which stops the tool from updating its configuration with the selected role.  The second option forces the printing of the ACCESS key ID information as environment variables to STDOUT.  With these 2 options enabled a user can, in 2 separate terminals invoke:

Terminal 1: `okta-awscli -ne --profile dev`
Terminal 2: `okta-awscli -ne --profile test`

By then capturing the environment variables the user can then interact with Terraform, AWS CLI, Boto3 scripts, etc as the AWS role assumed in each terminal session, allowing them to work with 2 separate AWS accounts simultaneously.