### PR TITLE
use the aws credentials profile from ~/.okta-aws if defined

### DIFF
--- a/oktaawscli/okta_auth_config.py
+++ b/oktaawscli/okta_auth_config.py
@@ -93,6 +93,14 @@ class OktaAuthConfig():
                 )
         return None
 
+    def profile_for(self, okta_profile):
+        """ Gets profile from config """
+        if self._value.has_option(okta_profile, 'profile'):
+            profile = self._value.get(okta_profile, 'profile')
+            self.logger.debug("Setting profile to %s" % profile)
+            return profile
+        return None
+
     def write_role_to_profile(self, okta_profile, role_arn):
         """ Saves role to profile in config """
         if not self._value.has_section(okta_profile):

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -111,6 +111,13 @@ def main(okta_profile, profile, verbose, version,
     if not okta_profile:
         okta_profile = "default"
 
+    okta_auth_config = OktaAuthConfig(logger)
+    profile_from_config = okta_auth_config.profile_for(okta_profile)
+    if not profile and not profile_from_config:
+        logger.info("No aws profile to store credentials has been provided or found in %s okta profile" % okta_profile)
+    elif not profile and profile_from_config:
+        profile = profile_from_config
+
     aws_auth = AwsAuth(profile, okta_profile, lookup, verbose, logger)
     if not aws_auth.check_sts_token(profile) or force:
         if force and profile:


### PR DESCRIPTION
proposal fix for #155
1) Extending OktaAuthConfig class with profile_for method
2) If an aws profile hasn't been provided as parameter check the okta profile