### PR TITLE
Don't raise TypeError when there is no valid SAML assertion in the end.

### DIFF
--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -142,7 +142,7 @@ Please enroll an MFA factor in the Okta Web UI first!""")
         assertion = self.get_simple_assertion(html) or self.get_mfa_assertion(html)
 
         if not assertion:
-            self.logger.error("SAML assertion not valid: " + assertion)
+            self.logger.error("SAML assertion not valid: %s", assertion)
             sys.exit(-1)
         return assertion
 


### PR DESCRIPTION
Fixes #109

This is a minimal fix for the TypeError itself. It doesn't address to root cause of why there was no valid SAML assertion. It also doesn't address the potential lack of feedback.