### PR TITLE
Allow setting the user agent

### DIFF
--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -14,7 +14,7 @@ from oktaawscli.util import input
 class OktaAuth():
     """ Handles auth to Okta and returns SAML assertion """
     def __init__(self, okta_profile, verbose, logger, totp_token, 
-        okta_auth_config, username, password, verify_ssl=True):
+        okta_auth_config, username, password, verify_ssl=True, user_agent=None):
 
         self.okta_profile = okta_profile
         self.totp_token = totp_token
@@ -24,11 +24,15 @@ class OktaAuth():
         self.factor = okta_auth_config.factor_for(okta_profile)
         self.app_link = okta_auth_config.app_link_for(okta_profile)
         self.okta_auth_config = okta_auth_config
+        self.user_agent = user_agent
         self.session = requests.Session()
         self.session_token = ""
         self.session_id = ""
         self.https_base_url = "https://%s" % okta_auth_config.base_url_for(okta_profile)
         self.auth_url = "%s/api/v1/authn" % self.https_base_url
+
+        if self.user_agent:
+            self.session.headers.update({'User-Agent': self.user_agent})
 
         if username:
             self.username = username

--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -24,7 +24,7 @@ class OktaAuth():
         self.factor = okta_auth_config.factor_for(okta_profile)
         self.app_link = okta_auth_config.app_link_for(okta_profile)
         self.okta_auth_config = okta_auth_config
-        self.session = None
+        self.session = requests.Session()
         self.session_token = ""
         self.session_id = ""
         self.https_base_url = "https://%s" % okta_auth_config.base_url_for(okta_profile)
@@ -47,7 +47,6 @@ class OktaAuth():
             "username": self.username,
             "password": self.password
         }
-        self.session = requests.Session()
         resp = self.session.post(self.auth_url, json=auth_data)
         resp_json = resp.json()
         self.cookies = resp.cookies

--- a/oktaawscli/okta_auth_mfa_app.py
+++ b/oktaawscli/okta_auth_mfa_app.py
@@ -73,11 +73,13 @@ class OktaAuthMfaApp():
 
 
     def _get_headers(self):
-        return {
-            'User-Agent': "okta-awscli/%s" % __version__,
+        headers = {
             'Accept': 'application/json',
             'Content-Type': 'application/json'
         }
+        if 'User-Agent' not in self.session.headers:
+            headers['User-Agent'] = "okta-awscli/%s" % __version__
+        return headers
 
 
     def _choose_factor(self, factors):

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -12,12 +12,13 @@ from oktaawscli.aws_auth import AwsAuth
 
 def get_credentials(aws_auth, okta_profile, profile,
                     verbose, logger, totp_token, cache, refresh_role, 
-                    okta_username=None, okta_password=None):
+                    okta_username=None, okta_password=None,
+                    user_agent=None):
     """ Gets credentials from Okta """
 
     okta_auth_config = OktaAuthConfig(logger)
     okta = OktaAuth(okta_profile, verbose, logger, totp_token, 
-        okta_auth_config, okta_username, okta_password)
+        okta_auth_config, okta_username, okta_password, user_agent=user_agent)
 
 
     _, assertion = okta.get_assertion()
@@ -87,10 +88,12 @@ to ~/.okta-credentials.cache\n')
 @click.option('-l', '--lookup', is_flag=True, help='Look up AWS account names')
 @click.option('-U', '--username', 'okta_username', help="Okta username")
 @click.option('-P', '--password', 'okta_password', help="Okta password")
+@click.option('--user-agent', help="In requests to Okta, set the user agent header to this")
 @click.argument('awscli_args', nargs=-1, type=click.UNPROCESSED)
 def main(okta_profile, profile, verbose, version,
          debug, force, cache, lookup, awscli_args,
-         refresh_role, token, okta_username, okta_password):
+         refresh_role, token, okta_username, okta_password,
+         user_agent):
     """ Authenticate to awscli using Okta """
     if version:
         print(__version__)
@@ -118,7 +121,8 @@ def main(okta_profile, profile, verbose, version,
             logger.info("Force option selected, \
                 getting new credentials anyway.")
         get_credentials(
-            aws_auth, okta_profile, profile, verbose, logger, token, cache, refresh_role, okta_username, okta_password
+            aws_auth, okta_profile, profile, verbose, logger, token, cache, refresh_role, okta_username, okta_password,
+            user_agent
         )
 
     if awscli_args:


### PR DESCRIPTION
Adds a `--user-agent` command-line option. This sets the User-Agent HTTP header when making requests to Okta.