### PR TITLE
Show number when user is on 3-number challenge view in Okta Verify.

### DIFF
--- a/oktaawscli/okta_auth_mfa_base.py
+++ b/oktaawscli/okta_auth_mfa_base.py
@@ -97,6 +97,7 @@ class OktaAuthMfaBase():
                 return resp_json['sessionToken']
             elif resp_json['status'] == "MFA_CHALLENGE" and factor['factorType'] !='u2f':
                 print("Waiting for push verification...")
+                correct_answer_shown = False
                 while True:
                     resp = requests.post(
                         resp_json['_links']['next']['href'], json=req_data)
@@ -113,6 +114,14 @@ class OktaAuthMfaBase():
                         print("Verification was rejected")
                         sys.exit(1)
                     else:
+                        if not correct_answer_shown:
+                            try:
+                                correct_answer = resp_json['_embedded']['factor']['_embedded']['challenge']['correctAnswer']
+                                if correct_answer:
+                                    print(f'On your phone, tap {correct_answer} in the Okta Verify app')
+                                    correct_answer_shown = True
+                            except KeyError:
+                                pass
                         time.sleep(0.5)
 
             if factor['factorType'] == 'u2f':


### PR DESCRIPTION
While polling for [verify push factor endpoint](https://developer.okta.com/docs/reference/api/authn/#verify-push-factor), if the Okta api includes a `correctNumber` in the response, print that number once before continuing to poll.

Fixes #170