### PR TITLE
Persistent okta sessions

### DIFF
--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -55,7 +55,7 @@ class OktaAuth():
             if resp_json['status'] == 'MFA_REQUIRED':
                 factors_list = resp_json['_embedded']['factors']
                 state_token = resp_json['stateToken']
-                mfa_base = OktaAuthMfaBase(self.logger, state_token, self.factor, self.totp_token)
+                mfa_base = OktaAuthMfaBase(self.logger, state_token, self.factor, self.totp_token, self.session)
                 session_token = mfa_base.verify_mfa(factors_list)
             elif resp_json['status'] == 'SUCCESS':
                 session_token = resp_json['sessionToken']

--- a/oktaawscli/okta_auth_mfa_base.py
+++ b/oktaawscli/okta_auth_mfa_base.py
@@ -10,11 +10,12 @@ except ImportError:
 
 class OktaAuthMfaBase():
     """ Handles base org Okta MFA """
-    def __init__(self, logger, state_token, factor, totp_token=None):
+    def __init__(self, logger, state_token, factor, totp_token=None, session=None):
         self.state_token = state_token
         self.logger = logger
         self.factor = factor
         self.totp_token = totp_token
+        self.session = requests.Session() if session is None else session
 
 
     def verify_mfa(self, factors_list):
@@ -90,7 +91,7 @@ class OktaAuthMfaBase():
                 req_data['answer'] = input('Enter MFA verification code: ')
 
         post_url = factor['_links']['verify']['href']
-        resp = requests.post(post_url, json=req_data)
+        resp = self.session.post(post_url, json=req_data)
         resp_json = resp.json()
         if 'status' in resp_json:
             if resp_json['status'] == "SUCCESS":
@@ -98,7 +99,7 @@ class OktaAuthMfaBase():
             elif resp_json['status'] == "MFA_CHALLENGE" and factor['factorType'] !='u2f':
                 print("Waiting for push verification...")
                 while True:
-                    resp = requests.post(
+                    resp = self.session.post(
                         resp_json['_links']['next']['href'], json=req_data)
                     resp_json = resp.json()
                     if resp_json['status'] == 'SUCCESS':
@@ -135,7 +136,7 @@ class OktaAuthMfaBase():
                             try:
                                 auth_response = u2f.authenticate(dev, challenge, resp_json['_embedded']['factor']['profile']['appId'] )
                                 req_data.update(auth_response)
-                                resp = requests.post(resp_json['_links']['next']['href'], json=req_data)
+                                resp = self.session.post(resp_json['_links']['next']['href'], json=req_data)
                                 resp_json = resp.json()
                                 if resp_json['status'] == 'SUCCESS':
                                     return resp_json['sessionToken']

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -90,11 +90,13 @@ to ~/.okta-credentials.cache\n')
 @click.option('-P', '--password', 'okta_password', help="Okta password")
 @click.option('-j', '--cookie-jar', type=click.Path(dir_okay=False, writable=True, resolve_path=True),
               help='Keep persistent Okta cookies in FILE')
+@click.option('-s', '--persistent-okta-session', is_flag=True,
+              help='Store and reuse the Okta session when possible')
 @click.argument('awscli_args', nargs=-1, type=click.UNPROCESSED)
 def main(okta_profile, profile, verbose, version,
          debug, force, cache, lookup, awscli_args,
          refresh_role, token, okta_username, okta_password,
-         cookie_jar):
+         cookie_jar, persistent_okta_session):
     """ Authenticate to awscli using Okta """
     if version:
         print(__version__)

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -47,7 +47,6 @@ def get_credentials(aws_auth, okta_profile, profile,
                          (os.path.expanduser('~'),), 'w')
             cache.write(exports)
             cache.close()
-        sys.exit(0)
     else:
         aws_auth.write_sts_token(access_key_id,
                                  secret_access_key, session_token)

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -13,12 +13,13 @@ from oktaawscli.aws_auth import AwsAuth
 
 def get_credentials(aws_auth, okta_profile, profile,
                     verbose, logger, totp_token, cache, refresh_role,
-                    okta_username=None, okta_password=None):
+                    okta_username=None, okta_password=None,
+                    cookie_jar=None):
     """ Gets credentials from Okta """
 
     okta_auth_config = OktaAuthConfig(logger)
-    okta = OktaAuth(okta_profile, verbose, logger, totp_token, 
-        okta_auth_config, okta_username, okta_password)
+    okta = OktaAuth(okta_profile, verbose, logger, totp_token,
+        okta_auth_config, okta_username, okta_password, cookie_jar=cookie_jar)
 
 
     _, assertion = okta.get_assertion()
@@ -129,7 +130,8 @@ def main(okta_profile, profile, verbose, version,
             except OSError as e:
                 logger.debug('Error loading cookies from %s: %s', cookie_jar.filename, e)
         get_credentials(
-            aws_auth, okta_profile, profile, verbose, logger, token, cache, refresh_role, okta_username, okta_password
+            aws_auth, okta_profile, profile, verbose, logger, token, cache, refresh_role, okta_username, okta_password,
+            cookie_jar
         )
         if cookie_jar is not None:
             try:

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -125,7 +125,7 @@ def main(okta_profile, profile, verbose, version,
         if cookie_jar is not None:
             cookie_jar = LWPCookieJar(cookie_jar)
             try:
-                cookie_jar.load()
+                cookie_jar.load(ignore_discard=persistent_okta_session, ignore_expires=persistent_okta_session)
                 logger.debug('Loaded cookies from %s: %r', cookie_jar.filename, cookie_jar)
             except LoadError as e:
                 logger.debug('Error loading cookies from %s: %s', cookie_jar.filename, e)
@@ -137,7 +137,7 @@ def main(okta_profile, profile, verbose, version,
         )
         if cookie_jar is not None:
             try:
-                cookie_jar.save()
+                cookie_jar.save(ignore_discard=persistent_okta_session, ignore_expires=persistent_okta_session)
                 logger.debug('Saved cookies to %s', cookie_jar.filename)
             except OSError as e:
                 logger.warning('Failed to save cookies to %s: %s', cookie_jar.filename, e)

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -14,7 +14,7 @@ from oktaawscli.aws_auth import AwsAuth
 def get_credentials(aws_auth, okta_profile, profile,
                     verbose, logger, totp_token, cache, refresh_role,
                     okta_username=None, okta_password=None,
-                    cookie_jar=None):
+                    cookie_jar=None, persistent_okta_session=False):
     """ Gets credentials from Okta """
 
     okta_auth_config = OktaAuthConfig(logger)
@@ -22,7 +22,7 @@ def get_credentials(aws_auth, okta_profile, profile,
         okta_auth_config, okta_username, okta_password, cookie_jar=cookie_jar)
 
 
-    _, assertion = okta.get_assertion()
+    _, assertion = okta.get_assertion(persistent_okta_session)
     role = aws_auth.choose_aws_role(assertion, refresh_role)
     principal_arn, role_arn = role
 
@@ -133,7 +133,7 @@ def main(okta_profile, profile, verbose, version,
                 logger.debug('Error loading cookies from %s: %s', cookie_jar.filename, e)
         get_credentials(
             aws_auth, okta_profile, profile, verbose, logger, token, cache, refresh_role, okta_username, okta_password,
-            cookie_jar
+            cookie_jar, persistent_okta_session,
         )
         if cookie_jar is not None:
             try:

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -86,6 +86,8 @@ to ~/.okta-credentials.cache\n')
 @click.option('-l', '--lookup', is_flag=True, help='Look up AWS account names')
 @click.option('-U', '--username', 'okta_username', help="Okta username")
 @click.option('-P', '--password', 'okta_password', help="Okta password")
+@click.option('-j', '--cookie-jar', type=click.Path(dir_okay=False, writable=True, resolve_path=True),
+              help='Keep persistent Okta cookies in FILE')
 @click.argument('awscli_args', nargs=-1, type=click.UNPROCESSED)
 def main(okta_profile, profile, verbose, version,
          debug, force, cache, lookup, awscli_args,


### PR DESCRIPTION
This include code that is part of pull request #167.

Adds a `-s`/`--persistent-okta-session` option to the command line.

With this option:

* Okta session cookies are also stored in the cookie jar
* When the STS session expires, first we check if the Okta session is still valid
* If the Okta session is still valid we re-use it to get a new STS session without re-authenticating to Okta and potentially triggering another MFA.
* If the Okta session is invalid we do re-authenticate to Okta.
* The `-f`/`--force` option forces re-authenticating with Okta by ignoring any valid STS session and any valid Okta session.