### PR TITLE
Omit the print of AWS credentials in the console unless verbose option is passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.5.1] 2022-03-04
+### Fixed
+- Omitting the print of AWS credentials, unless the verbose option is passed. ([#177](https://github.com/okta-awscli/okta-awscli/pull/177))
 ## [0.5.0] 2021-02-20
 ### Added
 - Command-line argument for refreshing AWS roles. ([#150](https://github.com/jmhale/okta-awscli/issues/150))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [0.5.1] 2022-03-04
 ### Fixed
 - Omitting the print of AWS credentials, unless the verbose option is passed. ([#177](https://github.com/okta-awscli/okta-awscli/pull/177))
+
 ## [0.5.0] 2021-02-20
 ### Added
 - Command-line argument for refreshing AWS roles. ([#150](https://github.com/jmhale/okta-awscli/issues/150))

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Optional flags:
 - `--force` or `-f` Ignores result of STS credentials validation and gets new credentials from AWS. Used in conjunction with `--profile`.
 - `--verbose` or `-v` More verbose output.
 - `--debug` or `-d` Very verbose output. Useful for debugging.
+- `--silent` or `-s` Silences the output of the AWS credentials.
 - `--cache` or `-c` Cache the acquired credentials to ~/.okta-credentials.cache (only if --profile is unspecified)
 - `--okta-profile` or `-o` Use a Okta profile, other than `default` in `.okta-aws`. Useful for multiple Okta tenants.
 - `--token` or `-t` Pass in the TOTP token from your authenticator

--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ Optional flags:
 - `--force` or `-f` Ignores result of STS credentials validation and gets new credentials from AWS. Used in conjunction with `--profile`.
 - `--verbose` or `-v` More verbose output.
 - `--debug` or `-d` Very verbose output. Useful for debugging.
-- `--silent` or `-s` Silences the output of the AWS credentials.
 - `--cache` or `-c` Cache the acquired credentials to ~/.okta-credentials.cache (only if --profile is unspecified)
 - `--okta-profile` or `-o` Use a Okta profile, other than `default` in `.okta-aws`. Useful for multiple Okta tenants.
 - `--token` or `-t` Pass in the TOTP token from your authenticator

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -11,7 +11,7 @@ from oktaawscli.okta_auth_config import OktaAuthConfig
 from oktaawscli.aws_auth import AwsAuth
 
 def get_credentials(aws_auth, okta_profile, profile,
-                    verbose, silent, logger, totp_token, cache, refresh_role, 
+                    verbose, logger, totp_token, cache, refresh_role, 
                     okta_username=None, okta_password=None):
     """ Gets credentials from Okta """
 
@@ -41,7 +41,7 @@ def get_credentials(aws_auth, okta_profile, profile,
     logger.info("Session token expires on: %s" % session_token_expiry)
     if not aws_auth.profile:
         exports = console_output(access_key_id, secret_access_key,
-                                 session_token, verbose, silent)
+                                 session_token, verbose)
         if cache:
             cache = open("%s/.okta-credentials.cache" %
                          (os.path.expanduser('~'),), 'w')
@@ -53,16 +53,15 @@ def get_credentials(aws_auth, okta_profile, profile,
                                  secret_access_key, session_token)
 
 
-def console_output(access_key_id, secret_access_key, session_token, verbose, silent):
+def console_output(access_key_id, secret_access_key, session_token, verbose):
     """ Outputs STS credentials to console """
-    if verbose:
-        print("Use these to set your environment variables:")
     exports = "\n".join([
         "export AWS_ACCESS_KEY_ID=%s" % access_key_id,
         "export AWS_SECRET_ACCESS_KEY=%s" % secret_access_key,
         "export AWS_SESSION_TOKEN=%s" % session_token
     ])
-    if not silent:
+    if verbose:
+        print("Use these to set your environment variables:")
         print(exports)
 
     return exports
@@ -71,7 +70,6 @@ def console_output(access_key_id, secret_access_key, session_token, verbose, sil
 # pylint: disable=R0913
 @click.command()
 @click.option('-v', '--verbose', is_flag=True, help='Enables verbose mode')
-@click.option('-s', '--silent', is_flag=True, help='Silences the output of the AWS credentials', default=False)
 @click.option('-V', '--version', is_flag=True,
               help='Outputs version number and sys.exits')
 @click.option('-d', '--debug', is_flag=True, help='Enables debug mode')
@@ -90,7 +88,7 @@ to ~/.okta-credentials.cache\n')
 @click.option('-U', '--username', 'okta_username', help="Okta username")
 @click.option('-P', '--password', 'okta_password', help="Okta password")
 @click.argument('awscli_args', nargs=-1, type=click.UNPROCESSED)
-def main(okta_profile, profile, verbose, silent, version,
+def main(okta_profile, profile, verbose, version,
          debug, force, cache, lookup, awscli_args,
          refresh_role, token, okta_username, okta_password):
     """ Authenticate to awscli using Okta """
@@ -120,7 +118,7 @@ def main(okta_profile, profile, verbose, silent, version,
             logger.info("Force option selected, \
                 getting new credentials anyway.")
         get_credentials(
-            aws_auth, okta_profile, profile, verbose, silent, logger, token, cache, refresh_role, okta_username, okta_password
+            aws_auth, okta_profile, profile, verbose, logger, token, cache, refresh_role, okta_username, okta_password
         )
 
     if awscli_args:

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -11,7 +11,7 @@ from oktaawscli.okta_auth_config import OktaAuthConfig
 from oktaawscli.aws_auth import AwsAuth
 
 def get_credentials(aws_auth, okta_profile, profile,
-                    verbose, slient, logger, totp_token, cache, refresh_role, 
+                    verbose, silent, logger, totp_token, cache, refresh_role, 
                     okta_username=None, okta_password=None):
     """ Gets credentials from Okta """
 
@@ -41,7 +41,7 @@ def get_credentials(aws_auth, okta_profile, profile,
     logger.info("Session token expires on: %s" % session_token_expiry)
     if not aws_auth.profile:
         exports = console_output(access_key_id, secret_access_key,
-                                 session_token, verbose, slient)
+                                 session_token, verbose, silent)
         if cache:
             cache = open("%s/.okta-credentials.cache" %
                          (os.path.expanduser('~'),), 'w')
@@ -53,7 +53,7 @@ def get_credentials(aws_auth, okta_profile, profile,
                                  secret_access_key, session_token)
 
 
-def console_output(access_key_id, secret_access_key, session_token, verbose, slient):
+def console_output(access_key_id, secret_access_key, session_token, verbose, silent):
     """ Outputs STS credentials to console """
     if verbose:
         print("Use these to set your environment variables:")
@@ -62,7 +62,7 @@ def console_output(access_key_id, secret_access_key, session_token, verbose, sli
         "export AWS_SECRET_ACCESS_KEY=%s" % secret_access_key,
         "export AWS_SESSION_TOKEN=%s" % session_token
     ])
-    if not slient:
+    if not silent:
         print(exports)
 
     return exports
@@ -71,7 +71,7 @@ def console_output(access_key_id, secret_access_key, session_token, verbose, sli
 # pylint: disable=R0913
 @click.command()
 @click.option('-v', '--verbose', is_flag=True, help='Enables verbose mode')
-@click.option('-s', '--slient', is_flag=True, help='Silences the output of the AWS credentials', default=False)
+@click.option('-s', '--silent', is_flag=True, help='Silences the output of the AWS credentials', default=False)
 @click.option('-V', '--version', is_flag=True,
               help='Outputs version number and sys.exits')
 @click.option('-d', '--debug', is_flag=True, help='Enables debug mode')
@@ -90,7 +90,7 @@ to ~/.okta-credentials.cache\n')
 @click.option('-U', '--username', 'okta_username', help="Okta username")
 @click.option('-P', '--password', 'okta_password', help="Okta password")
 @click.argument('awscli_args', nargs=-1, type=click.UNPROCESSED)
-def main(okta_profile, profile, verbose, slient, version,
+def main(okta_profile, profile, verbose, silent, version,
          debug, force, cache, lookup, awscli_args,
          refresh_role, token, okta_username, okta_password):
     """ Authenticate to awscli using Okta """
@@ -120,7 +120,7 @@ def main(okta_profile, profile, verbose, slient, version,
             logger.info("Force option selected, \
                 getting new credentials anyway.")
         get_credentials(
-            aws_auth, okta_profile, profile, verbose, slient, logger, token, cache, refresh_role, okta_username, okta_password
+            aws_auth, okta_profile, profile, verbose, silent, logger, token, cache, refresh_role, okta_username, okta_password
         )
 
     if awscli_args:

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -11,7 +11,7 @@ from oktaawscli.okta_auth_config import OktaAuthConfig
 from oktaawscli.aws_auth import AwsAuth
 
 def get_credentials(aws_auth, okta_profile, profile,
-                    verbose, logger, totp_token, cache, refresh_role, 
+                    verbose, slient, logger, totp_token, cache, refresh_role, 
                     okta_username=None, okta_password=None):
     """ Gets credentials from Okta """
 
@@ -41,7 +41,7 @@ def get_credentials(aws_auth, okta_profile, profile,
     logger.info("Session token expires on: %s" % session_token_expiry)
     if not aws_auth.profile:
         exports = console_output(access_key_id, secret_access_key,
-                                 session_token, verbose)
+                                 session_token, verbose, slient)
         if cache:
             cache = open("%s/.okta-credentials.cache" %
                          (os.path.expanduser('~'),), 'w')
@@ -53,7 +53,7 @@ def get_credentials(aws_auth, okta_profile, profile,
                                  secret_access_key, session_token)
 
 
-def console_output(access_key_id, secret_access_key, session_token, verbose):
+def console_output(access_key_id, secret_access_key, session_token, verbose, slient):
     """ Outputs STS credentials to console """
     if verbose:
         print("Use these to set your environment variables:")
@@ -62,7 +62,8 @@ def console_output(access_key_id, secret_access_key, session_token, verbose):
         "export AWS_SECRET_ACCESS_KEY=%s" % secret_access_key,
         "export AWS_SESSION_TOKEN=%s" % session_token
     ])
-    print(exports)
+    if not slient:
+        print(exports)
 
     return exports
 
@@ -70,6 +71,7 @@ def console_output(access_key_id, secret_access_key, session_token, verbose):
 # pylint: disable=R0913
 @click.command()
 @click.option('-v', '--verbose', is_flag=True, help='Enables verbose mode')
+@click.option('-s', '--slient', is_flag=True, help='Silences the output of the AWS credentials', default=False)
 @click.option('-V', '--version', is_flag=True,
               help='Outputs version number and sys.exits')
 @click.option('-d', '--debug', is_flag=True, help='Enables debug mode')
@@ -88,7 +90,7 @@ to ~/.okta-credentials.cache\n')
 @click.option('-U', '--username', 'okta_username', help="Okta username")
 @click.option('-P', '--password', 'okta_password', help="Okta password")
 @click.argument('awscli_args', nargs=-1, type=click.UNPROCESSED)
-def main(okta_profile, profile, verbose, version,
+def main(okta_profile, profile, verbose, slient, version,
          debug, force, cache, lookup, awscli_args,
          refresh_role, token, okta_username, okta_password):
     """ Authenticate to awscli using Okta """
@@ -118,7 +120,7 @@ def main(okta_profile, profile, verbose, version,
             logger.info("Force option selected, \
                 getting new credentials anyway.")
         get_credentials(
-            aws_auth, okta_profile, profile, verbose, logger, token, cache, refresh_role, okta_username, okta_password
+            aws_auth, okta_profile, profile, verbose, slient, logger, token, cache, refresh_role, okta_username, okta_password
         )
 
     if awscli_args:

--- a/oktaawscli/version.py
+++ b/oktaawscli/version.py
@@ -1,2 +1,2 @@
 """ version string """
-__version__ = '0.5.0'
+__version__ = '0.5.1'


### PR DESCRIPTION
Hi,
Thank you for this repo, we're using it as our sso cli tool to access AWS accounts.

we had to modify it a bit to omit the print of the AWS credentials to the console while authenticating.
This MR contains the code change for that, it doesn't change the default behaviour.

Thanks.
Sadok