### PR TITLE
Updating okta_auth.py with debug information on verification title

### DIFF
--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -129,7 +129,7 @@ Please contact you administrator in order to unlock the account!""")
         if hasattr(soup.title, 'string') and re.match(".* - Extra Verification$", soup.title.string):
             state_token = decode(re.search(r"var stateToken = '(.*)';", html.text).group(1), "unicode-escape")
         else:
-            self.logger.error(f'No Extra Verification. Title was {soup.title}')
+            self.logger.error(f"No Extra Verification. Title was {soup.title}")
             return None
 
         self.session.cookies['oktaStateToken'] = state_token

--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -126,11 +126,10 @@ Please contact you administrator in order to unlock the account!""")
 
     def get_mfa_assertion(self, html):
         soup = bs(html.text, "html.parser")
-        self.logger.debug(soup.title)
         if hasattr(soup.title, 'string') and re.match(".* - Extra Verification$", soup.title.string):
             state_token = decode(re.search(r"var stateToken = '(.*)';", html.text).group(1), "unicode-escape")
         else:
-            self.logger.error("No Extra Verification")
+            self.logger.error(f'No Extra Verification. Title was {soup.title}')
             return None
 
         self.session.cookies['oktaStateToken'] = state_token

--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -126,6 +126,7 @@ Please contact you administrator in order to unlock the account!""")
 
     def get_mfa_assertion(self, html):
         soup = bs(html.text, "html.parser")
+        self.logger.debug(soup.title)
         if hasattr(soup.title, 'string') and re.match(".* - Extra Verification$", soup.title.string):
             state_token = decode(re.search(r"var stateToken = '(.*)';", html.text).group(1), "unicode-escape")
         else:


### PR DESCRIPTION
In the case, the application title doesn't have the text 'Extra Verification' add a debug option to print to the console to figure out what it's being displayed instead.

I realized my app access was "locked". Adding a logging statement here helped me understand what was trying to be parsed. I think adding this could be a better error message rather than just "No Extra Verification", but let me know what you think! :) 

It might help other users figure out what's wrong in their system since the error message is a bit generic: https://github.com/okta-awscli/okta-awscli/issues/197

<img width="663" alt="Screen Shot 2023-01-29 at 9 00 43 AM" src="https://user-images.githubusercontent.com/8705429/215335069-151becd2-84ea-4485-a67c-79139c737031.png">
