### PR TITLE
Hal/fea load secrets from env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Support python 3.11
 - Bumped `click` from `7.0` to `8.1.3`
 - Bumped `validators` from `0.11.2` to `0.20.0`
-- Added jinja2 as a dependency for interpolating environment variables into config values.
+
 ## [0.5.5rc] 2023-03-11
 - Bugfix [#199](https://github.com/okta-awscli/okta-awscli/issues/199) duplicates of data inside config file
 - Bump certifi from 2021.10.8 to 2022.12.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+
+## [0.6.0rc] 2023-05-10
+- Add ability to load configuration data from environment variables using jinja2 syntax
+- Support python 3.11
+- Bumped `click` from `7.0` to `8.1.3`
+- Bumped `validators` from `0.11.2` to `0.20.0`
+- Added jinja2 as a dependency for interpolating environment variables into config values.
 ## [0.5.5rc] 2023-03-11
 - Bugfix [#199](https://github.com/okta-awscli/okta-awscli/issues/199) duplicates of data inside config file
 - Bump certifi from 2021.10.8 to 2022.12.7

--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ base-url = <your_okta_org>.okta.com
 
 ## The remaining parameters are optional.
 ## You may be prompted for them, if they're not included here.
-username = <your_okta_username>
-password = <your_okta_password> # Only save your password if you know what you are doing!
-factor   = <your_preferred_mfa_factor> # Current choices are: GOOGLE or OKTA
-role     = <your_preferred_okta_role> # AWS role name (match one of the options prompted for by "Please select the AWS role" when this parameter is not specified
-profile  = <aws_profile_to_store_credentials> # Sets your temporary credentials to a profile in `.aws/credentials`. Overridden by `--profile` command line flag
-app-link = <app_link_from_okta> # Found in Okta's configuration for your AWS account.
+username = <your_okta_username or env_var>
+password = <your_okta_password or env_var> # Only save your password if you know what you are doing!
+factor   = <your_preferred_mfa_factor or env_var> # Current choices are: GOOGLE or OKTA
+role     = <your_preferred_okta_role or env_var> # AWS role name (match one of the options prompted for by "Please select the AWS role" when this parameter is not specified
+profile  = <aws_profile_to_store_credentials or env_var> # Sets your temporary credentials to a profile in `.aws/credentials`. Overridden by `--profile` command line flag
+app-link = <app_link_from_okta or env_var> # Found in Okta's configuration for your AWS account.
 duration = 3600 # duration in seconds to request a session token for, make sure your accounts (both AWS itself and the associated okta application) allow for large durations. default: 3600
 ```
 
@@ -108,4 +108,30 @@ okta-awscli
 you can add this to you .bashrc 
 ```
 source <PATH TO GIT REPO>/set-alias.bash
+```
+
+## Using Environment Variables in the config file ~/.okta-aws
+
+Since version 0.6.0rc1, it is possible to load configuration parameters from the environment.
+
+example config file:
+```
+[my_role]
+base-url = my-company.okta.com
+profile = my_role
+password = {{ OKTA_password }}
+username = {{ OKTA_username }}
+duration = 24000
+app-link = https://my-company.okta.com/home/amazon_aws/0kladsjfj13478990/123
+role = arn:aws:iam::12345678910123:role/{{ OKTA_my_role_name }}
+totp_token = {{ OKTA_totp }}
+```
+
+It would then be possible to specify the variables when okta-awscli is invoked, or to specify them via an .env file
+```
+OKTA_password=supersecret OKTA_username=fname.lname@email.com OKTA_totp=123456 okta-awscli -o my_role
+```
+or, from a directly where an `.env` file is defined.
+```
+dotenv run -- okta-awsli -o my_role
 ```

--- a/README.md
+++ b/README.md
@@ -119,17 +119,17 @@ example config file:
 [my_role]
 base-url = my-company.okta.com
 profile = my_role
-password = {{ OKTA_password }}
-username = {{ OKTA_username }}
+password = $(OKTA_password)
+username = $(OKTA_username)
 duration = 24000
 app-link = https://my-company.okta.com/home/amazon_aws/0kladsjfj13478990/123
-role = arn:aws:iam::12345678910123:role/{{ OKTA_my_role_name }}
-totp_token = {{ OKTA_totp }}
+role = arn:aws:iam::12345678910123:role/$(OKTA_my_role_name)
+totp_token = $(OKTA_totp)
 ```
 
 It would then be possible to specify the variables when okta-awscli is invoked, or to specify them via an .env file
 ```
-OKTA_password=supersecret OKTA_username=fname.lname@email.com OKTA_totp=123456 okta-awscli -o my_role
+OKTA_password=supersecret OKTA_username=fname.lname@email.com OKTA_totp=123456 OKTA_my_role_name=myawsrole okta-awscli -o my_role
 ```
 or, from a directly where an `.env` file is defined.
 ```

--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -40,6 +40,11 @@ class OktaAuth():
         else:
             self.password = okta_auth_config.password_for(okta_profile)
 
+        if totp_token:
+            self.totp_token = totp_token
+        else:
+            self.totp_token = okta_auth_config.totp_token_for(okta_profile)
+            
     def primary_auth(self):
         """ Performs primary auth against Okta """
 

--- a/oktaawscli/okta_auth_config.py
+++ b/oktaawscli/okta_auth_config.py
@@ -2,41 +2,25 @@
 
 from errno import ESTALE
 import os
-import re
 import sys
-from configparser import RawConfigParser, _UNSET
+from configparser import ConfigParser
 from getpass import getpass
-from jinja2 import Template, StrictUndefined
-from jinja2.exceptions import UndefinedError
 import validators
 
 
 from oktaawscli.util import input
-
-class UndefinedEnvironmentVariable(Exception):
-    pass
-class JinjaConfigParser(RawConfigParser):
-    def get(self, section, option, *, raw=False, vars=None, fallback=_UNSET):
-        _value = super().get(section, option, raw=raw, vars=vars, fallback=fallback)
-        try:
-            value = Template(_value, undefined=StrictUndefined).render(os.environ)
-            return value
-        except UndefinedError as e:
-            raise UndefinedEnvironmentVariable(
-                f'Environment Variable {e.message} for `{section}.{option}`. Source string: {_value}'
-                )
 
 class OktaAuthConfig():
     """ Config helper class """
     def __init__(self, logger):
         self.logger = logger
         self.config_path = os.path.expanduser('~') + '/.okta-aws'
-        self._value = JinjaConfigParser()
+        self._value = ConfigParser(os.environ)
         self._value.read(self.config_path)
     
     @staticmethod
     def configure(logger):
-        value = JinjaConfigParser()
+        value = ConfigParser(os.environ)
         config_path = os.path.expanduser('~') + '/.okta-aws'
         config_exists = os.path.exists(config_path)
         if config_exists:
@@ -192,7 +176,7 @@ class OktaAuthConfig():
 
     @staticmethod
     def get_okta_profiles():
-        value = RawConfigParser()
+        value = ConfigParser(os.environ)
         config_path = os.path.expanduser('~') + '/.okta-aws'
         value.read(config_path)
         return value.sections()

--- a/oktaawscli/okta_auth_config.py
+++ b/oktaawscli/okta_auth_config.py
@@ -2,13 +2,31 @@
 
 from errno import ESTALE
 import os
+import re
 import sys
 from configparser import RawConfigParser
 from getpass import getpass
 import validators
+from validators.utils import validator
 
 
 from oktaawscli.util import input
+
+def get_maybe_env_var(input):
+    """ return value from environment if set. """
+    if env_var(input):
+        return os.environ.get(input.strip()[2:-1])
+    return input
+
+@validator
+def env_var(input):
+    """ validate input is can be an $-enclosed environment variable, e.g. `${ENV_VAR}` """
+    _input = input.strip()
+    return all([
+        _input[:2] == '${', 
+        _input[-1] == '}',
+        re.match(r'[a-zA-Z_]+[a-zA-Z0-9_]*', _input[2:-1])
+    ])
 
 class OktaAuthConfig():
     """ Config helper class """
@@ -22,24 +40,27 @@ class OktaAuthConfig():
     def configure(logger):
         value = RawConfigParser()
         config_path = os.path.expanduser('~') + '/.okta-aws'
-        if os.path.exists(config_path):
+        config_exists = os.path.exists(config_path)
+        if config_exists:
             value.read(config_path)
             print(f"You have preconfigured Okta profiles: {value.sections()}")
             print(f"This command will append new profile to the existing {config_path} config file")
+            
         else:
             print(f"This command will create a new {config_path} config file")
 
         confirm = input('Would you like to proceed? [y/n]: ')
         if confirm == 'y':
-            logger.info(f"Creating new {config_path} file")
+            logger.info(f"{'Appending config to' if config_exists else 'Creating new'} {config_path} file")
+            print("to specify an environment variable enter the variable name as `${ENV_VARIABLE_NAME}`")
             okta_profile = input('Enter Okta profile name: ')
             if not okta_profile:
                 okta_profile = 'default'
-            profile = input('Enter AWS profile name: ')
-            base_url = input('Enter Okta base url [your main organisation Okta url]: ')
-            username = input('Enter Okta username: ')
-            app_link = input('Enter AWS app-link [optional]: ')
-            duration = input('Duration in seconds to request a session token for [Default=3600]: ')
+            profile = input('Enter AWS profile name or env var: ')
+            base_url = input('Enter Okta base url or env var [your main organisation Okta url]: ')
+            username = input('Enter Okta username or env var: ')
+            app_link = input('Enter AWS app-link or env var [optional]: ')
+            duration = input('Duration in seconds or env var to request a session token for [Default=3600]: ')
             if not duration:
                 duration = 3600
 
@@ -84,7 +105,8 @@ class OktaAuthConfig():
             app_link = self._value.get(okta_profile, 'app-link')
         elif self._value.has_option('default', 'app-link'):
             app_link = self._value.get('default', 'app-link')
-
+        
+        app_link = get_maybe_env_var(app_link)
         if app_link:
             try:
                 if not validators.url(app_link):
@@ -98,12 +120,20 @@ class OktaAuthConfig():
             self.logger.error("The app-link is missing. Will try to retrieve it from Okta")
             return None
 
-        
+    def totp_token_for(self, okta_profile):
+        """ Reads the totp token from the env var """
+        if self._value.has_option(okta_profile, 'totp_token'):
+            token_var = self._value.get(okta_profile, 'totp_token')
+            token = get_maybe_env_var(token_var)
+        else:
+            token = input('Enter token: ')
+        return token
 
     def username_for(self, okta_profile):
         """ Gets username from config """
         if self._value.has_option(okta_profile, 'username'):
             username = self._value.get(okta_profile, 'username')
+            username = get_maybe_env_var(username)
             self.logger.info("Authenticating as: %s" % username)
         else:
             username = input('Enter username: ')
@@ -113,6 +143,7 @@ class OktaAuthConfig():
         """ Gets password from config """
         if self._value.has_option(okta_profile, 'password'):
             password = self._value.get(okta_profile, 'password')
+            password = get_maybe_env_var(password)
         else:
             password = getpass('Enter password: ')
         return password
@@ -129,6 +160,7 @@ class OktaAuthConfig():
         """ Gets requested duration from config, ignore it on failure """
         if self._value.has_option(okta_profile, 'duration'):
             duration = self._value.get(okta_profile, 'duration')
+            duration = get_maybe_env_var(duration)
             self.logger.debug(
                 "Requesting a duration of %s seconds" % duration
             )

--- a/oktaawscli/version.py
+++ b/oktaawscli/version.py
@@ -1,2 +1,2 @@
 """ version string """
-__version__ = '0.5.5rc'
+__version__ = '0.6.0rc'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests==2.27.1
-click==7.0
+click==8.1.3
 beautifulsoup4==4.11.1
 boto3==1.21.22
 ConfigParser==3.5.0
-validators==0.11.2
+validators==0.20.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ beautifulsoup4==4.11.1
 boto3==1.21.22
 ConfigParser==3.5.0
 validators==0.20.0
+jinja2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ beautifulsoup4==4.11.1
 boto3==1.21.22
 ConfigParser==3.5.0
 validators==0.20.0
-jinja2


### PR DESCRIPTION
# what it does

- add support to populate config parameters from the environment
- adds support for storing a reference to an environment variable for the totp_token (one time password)
- update requirements.txt file and bump the minor version as this is a backwards compatible enhancement.
- adds support for python 3.11

# why

- allowing config parameters to be populated from the environment lets this tool be used in a non-interactive way
- click needed to be updated for compatibility with python 3.11