### PR TITLE
Use Python 3.11 to resolve run issues with Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.11-alpine
 
 WORKDIR /opt/okta-awscli
 


### PR DESCRIPTION
When running Docker build per the README I'm getting the following error:

```
$ docker run -it --rm -v ~/.aws/credentials:/root/.aws/credentials -v ~/.okta-aws:/root/.okta-aws okta-awscli iam list-users
Traceback (most recent call last):
  File "/usr/local/bin/okta-awscli", line 10, in <module>
    from importlib.metadata import distribution
ModuleNotFoundError: No module named 'importlib.metadata'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/bin/okta-awscli", line 13, in <module>
    from importlib_metadata import distribution
  File "/usr/local/lib/python3.7/site-packages/importlib_metadata-6.8.0-py3.7.egg/importlib_metadata/__init__.py", line 6, in <module>
    import zipp
  File "/usr/local/lib/python3.7/site-packages/zipp-3.16.2-py3.7.egg/zipp/__init__.py", line 9, in <module>
    from .py310compat import text_encoding
  File "/usr/local/lib/python3.7/site-packages/zipp-3.16.2-py3.7.egg/zipp/py310compat.py", line 5
    def _text_encoding(encoding, stacklevel=2, /):  # pragma: no cover
                                               ^
SyntaxError: invalid syntax
```

Upgrading to using the `python:3.11-alpine` image resolves this issue for me and allows me to run okta-awscli inside the container.