### PR TITLE
Add support for FIDO2 YubiKey and Touch ID

### DIFF
--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -55,7 +55,9 @@ class OktaAuth():
             if resp_json['status'] == 'MFA_REQUIRED':
                 factors_list = resp_json['_embedded']['factors']
                 state_token = resp_json['stateToken']
-                mfa_base = OktaAuthMfaBase(self.logger, state_token, self.factor, self.totp_token)
+                mfa_base = OktaAuthMfaBase(self.logger, state_token,
+                        self.factor, self.totp_token,
+                        self.okta_auth_config.base_url_for(self.okta_profile))
                 session_token = mfa_base.verify_mfa(factors_list)
             elif resp_json['status'] == 'SUCCESS':
                 session_token = resp_json['sessionToken']

--- a/oktaawscli/okta_auth_mfa_base.py
+++ b/oktaawscli/okta_auth_mfa_base.py
@@ -1,6 +1,10 @@
 import time
 import sys
+import base64
+import traceback
+
 import requests
+
 try:
     from u2flib_host import u2f, exc
     from u2flib_host.constants import APDU_WRONG_DATA
@@ -8,13 +12,49 @@ try:
 except ImportError:
     U2F_ALLOWED = False
 
+
+try:
+    from typing import Any
+    from functools import reduce
+    from fido2.hid import CtapHidDevice
+    from fido2.utils import websafe_decode
+    from fido2.webauthn import (
+        PublicKeyCredentialDescriptor,
+        PublicKeyCredentialRequestOptions,
+        PublicKeyCredentialType,
+        UserVerificationRequirement,
+    )
+    from fido2.client import Fido2Client
+    from getpass import getpass
+    from typing import Optional
+    from fido2.client import UserInteraction
+    from fido2.ctap2.pin import ClientPin
+    WEBAUTHN_ALLOWED = True
+except ImportError:
+    WEBAUTHN_ALLOWED = False
+
+def v(d: dict[str, Any], key: str, default: Any = "") -> Any:
+    parts = key.split(".")
+    prop = parts[-1]
+    path = parts[:-1]
+
+    child = reduce(
+        lambda acc, v: acc.get(v, {}),
+        path,
+        d,
+    )
+
+    return child.get(prop, default)
+
 class OktaAuthMfaBase():
     """ Handles base org Okta MFA """
-    def __init__(self, logger, state_token, factor, totp_token=None):
+    def __init__(self, logger, state_token, factor, totp_token=None, base_url=None):
         self.state_token = state_token
         self.logger = logger
         self.factor = factor
         self.totp_token = totp_token
+        self.base_url = base_url
+        self.https_base_url = "https://%s" % base_url
 
 
     def verify_mfa(self, factors_list):
@@ -23,6 +63,8 @@ class OktaAuthMfaBase():
         supported_factor_types = ["token:software:totp", "push"]
         if U2F_ALLOWED:
             supported_factor_types.append("u2f")
+        if WEBAUTHN_ALLOWED:
+            supported_factor_types.append("webauthn")
 
         supported_factors = []
         for factor in factors_list:
@@ -62,6 +104,8 @@ class OktaAuthMfaBase():
                 else:
                     factor_name = "Unsupported factor type: %s" % factor_provider
 
+                factor_name = factor['factorType'] + ": " + (factor['profile'].get('authenticatorName') or factor['factorType'])
+
                 if self.factor:
                     if self.factor == factor_provider:
                         factor_choice = index
@@ -100,7 +144,7 @@ class OktaAuthMfaBase():
         if 'status' in resp_json:
             if resp_json['status'] == "SUCCESS":
                 return resp_json['sessionToken']
-            elif resp_json['status'] == "MFA_CHALLENGE" and factor['factorType'] !='u2f':
+            elif resp_json['status'] == "MFA_CHALLENGE" and factor['factorType'] !='u2f' and factor['factorType'] !='webauthn':
                 print("Waiting for push verification...")
                 correct_answer_shown = False
                 while True:
@@ -163,6 +207,97 @@ class OktaAuthMfaBase():
                                 if ex.code == APDU_WRONG_DATA:
                                     devices.remove(device)
                                 time.sleep(0.1)
+
+            if factor['factorType'] == 'webauthn' and factor['provider'] == 'FIDO':
+                class CliInteraction(UserInteraction):
+                    def __init__(self, user_interaction_msg):
+                        self.user_interaction_msg = user_interaction_msg
+
+                    def prompt_up(self) -> None:
+                        print(self.user_interaction_msg)
+
+                    def request_pin(
+                        self, _: ClientPin.PERMISSION, rp_id: Optional[str]
+                    ) -> Optional[str]:
+                        return getpass(f"Enter PIN to authenticate in {rp_id}: ")
+
+                    def request_uv(self, unused, unused_) -> bool:
+                        print("User Verification required.")
+                        return True
+
+                user_verification = UserVerificationRequirement.DISCOURAGED
+                devices = list(CtapHidDevice.list_devices())
+                if len(devices) == 0:
+                    self.logger.warning("No U2F device found. Exiting...")
+                    exit(1)
+                challenge = v(resp_json, '_embedded.factor._embedded.challenge.challenge')
+                challenge_b = websafe_decode(challenge)
+                credentialId = websafe_decode(v(resp_json,'_embedded.factor.profile.credentialId'))
+
+                result = None
+                while not result:
+                    for dev in devices:
+                        if isinstance(dev, CtapHidDevice):
+                            user_verification = UserVerificationRequirement.REQUIRED
+                        else:
+                            user_verification = UserVerificationRequirement.DISCOURAGED
+                        client = Fido2Client(dev, self.https_base_url)
+                        user_interaction_msg = (
+                            '!!! Touch the selected MFA device on your macOS laptop... !!!'
+                            if sys.platform == "darwin"
+                            else '!!! Touch the flashing U2F device to authenticate... !!!'
+                        )
+                        client = Fido2Client(
+                            device=dev,
+                            origin=self.https_base_url,
+                            user_interaction=CliInteraction(user_interaction_msg),
+                        )
+                        user_verification = (
+                            UserVerificationRequirement.REQUIRED
+                            if client.info.options.get('clientPin', False)
+                            else UserVerificationRequirement.DISCOURAGED
+                        )
+                        request = PublicKeyCredentialRequestOptions(
+                            challenge=challenge_b,
+                            timeout=100000,
+                            rp_id=self.base_url,
+                            allow_credentials=[
+                                PublicKeyCredentialDescriptor(
+                                    type=PublicKeyCredentialType.PUBLIC_KEY ,
+                                    id=credentialId
+                                )
+                            ],
+                            user_verification=user_verification,
+                        )
+                        try:
+                            result = client.get_assertion(request)
+                            assertion = result.get_response(0)
+                            self.logger.debug('assertion.result: %s', result)
+                            b64authenticatorData = (base64.b64encode(assertion.authenticator_data)).decode('ascii')
+                            b64clientData = assertion.client_data.b64
+                            b64signatureData = (base64.b64encode(assertion.signature)).decode('ascii')
+                            okta_response = {
+                                'authenticatorData': b64authenticatorData,
+                                'clientData': b64clientData,
+                                'signatureData': b64signatureData
+                            }
+                            req_data.update(okta_response)
+                            resp = requests.post(v(resp_json,'_links.next.href'), json=req_data)
+                            resp_json = resp.json()
+                            if resp_json['status'] == 'SUCCESS':
+                                return resp_json['sessionToken']
+                            elif resp_json['factorResult'] == 'TIMEOUT':
+                                self.logger.warning("Verification timed out")
+                                exit(1)
+                            elif resp_json['factorResult'] == 'REJECTED':
+                                self.logger.warning("Verification was rejected")
+                                exit(1)
+                            # break
+                        except Exception:
+                            traceback.print_exc(file=sys.stderr)
+                            result = None
+                    if not result:
+                        return None
 
         elif resp.status_code != 200:
             self.logger.error(resp_json['errorSummary'])

--- a/oktaawscli/okta_auth_mfa_base.py
+++ b/oktaawscli/okta_auth_mfa_base.py
@@ -227,6 +227,17 @@ class OktaAuthMfaBase():
 
                 user_verification = UserVerificationRequirement.DISCOURAGED
                 devices = list(CtapHidDevice.list_devices())
+                # Support for 'Touch ID' on macOS
+                if sys.platform == "darwin":
+                    from ctap_keyring_device.ctap_keyring_device import CtapKeyringDevice
+                    from ctap_keyring_device.ctap_strucs import CtapOptions
+                    # devices = devices + CtapKeyringDevice.list_devices()  # this is too noisy!
+                    # Dirty hack to detect that 'Touch ID' is being requested
+                    print("[DEBUG]", factor)
+                    if (factor["profile"]["authenticatorName"] is None) and ("yubi" not in ("%s" % factor["profile"]["authenticatorName"]).lower()):
+                        print("[DEBUG] - Invoking CtapKeyringDevice.list_devices() stuff...")
+                        devices = CtapKeyringDevice.list_devices()  # only try the 'Touch ID'
+                        print("[DEBUG]", devices)
                 if len(devices) == 0:
                     self.logger.warning("No U2F device found. Exiting...")
                     exit(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ beautifulsoup4==4.11.1
 boto3==1.21.22
 ConfigParser==3.5.0
 validators==0.11.2
+ctap-keyring-device@git+https://github.com/kholia/ctap-keyring-device@81ad9db90310b4224050b60eaf6fb1feac025119

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         'validators',
         ],
     extras_require={
-        'U2F': ['python-u2flib-host']
+        'U2F': ['python-u2flib-host'],
+        'FIDO2': ['fido2>=1.1.1'],
     },
 )


### PR DESCRIPTION
Related: https://github.com/okta-awscli/okta-awscli/issues/220.

This PR adds support for FIDO2 YubiKey(s).

It was tested with following YubiKey types:

- YubiKey 5 with NFC
- Security Key By Yubico with NFC

CC @maxtacu for review help with this PR.

Testing tips:

- You may need to test this PR with Python >= 3.10.x.

- Run `pip install "fido2>=1.1.1"` to install the `fido2` library.

- Also see https://github.com/Yubico/libfido2#installation.