### PR TITLE
Respect AWS_SHARED_CREDENTIALS_FILE environment variable when set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Bump certifi from 2021.10.8 to 2022.12.7
 - Bugfix/feature [#141](https://github.com/okta-awscli/okta-awscli/issues/141) require beautifulsoup4 instead of dummy package bs4
 - Bugfix for non-working factor provided by config and totp token given by `-t` argument if user has more than 1 factors 
+- Respect AWS_SHARED_CREDENTIALS_FILE environment variable when set
 
 ## [0.5.4] 2022-04-28
 - Bugfix for check_sts function when the profile name is already defined in `~/.okta-aws`. fixes [#161](https://github.com/okta-awscli/okta-awscli/issues/161) and [#155](https://github.com/okta-awscli/okta-awscli/issues/155)

--- a/oktaawscli/aws_auth.py
+++ b/oktaawscli/aws_auth.py
@@ -22,8 +22,13 @@ class AwsAuth():
 
     def __init__(self, profile, okta_profile, lookup, verbose, logger):
         home_dir = os.path.expanduser('~')
-        self.creds_dir = home_dir + "/.aws"
-        self.creds_file = self.creds_dir + "/credentials"
+        shared_credentials_file = os.getenv("AWS_SHARED_CREDENTIALS_FILE")
+        if shared_credentials_file:
+            self.creds_dir = os.path.dirname(shared_credentials_file)
+            self.creds_file = shared_credentials_file
+        else:
+            self.creds_dir = home_dir + "/.aws"
+            self.creds_file = self.creds_dir + "/credentials"
         self.lookup = lookup
         self.profile = profile
         self.verbose = verbose


### PR DESCRIPTION
Hello, while using the CLI I noticed that the path for AWS credentials is hardcoded to `$HOME/.aws/credentials`. While this is fine, it does not respect `AWS_SHARED_CREDENTIALS_FILE` env var, which may be used to specify the location of such credential file.

`AWS_SHARED_CREDENTIALS_FILE` is a documented AWS CLI environment variable, see https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html

This PR adds support for reading the value and configuring internal `AwsAuth` fields with the value extracted from it.

In this implementation the environment variable takes precedence over the default `$HOME/.aws` location, which is used as fallback when the environment variable is not present and to my understanding is how the AWS CLI works.

Thank you for considering this contribution!

