### PR TITLE
Add option to specify config file location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## [0.6.0] 2024-05-16
+### Added
+- Command-line flag to specify a non-default config file location.
+
 ## [0.5.5] 2024-03-19
 - Bugfix [#199](https://github.com/okta-awscli/okta-awscli/issues/199) duplicates of data inside config file
 - Bump certifi from 2021.10.8 to 2022.12.7

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Optional flags:
 - `--refresh-role` or `-r` Refresh the AWS role to be assumed. Previously incorporated in `--force`.
 - `--lookup` or `-l` Lookup and return the AWS Account Alias for each role, instead of returning the raw ARN. 
 - `--config` Add/Create new Okta profile configuration.
+- `--config-file` Specify a path to a file containing Okta profile configurations. Defaults to `~/.okta-aws`.
 - `-s` or `--switch` Switch to any existing profile and update credentials.
   - Note that this will attempt to perform `iam:ListAccountAliases` on every account that you have access to via Okta. This is important for two reasons:
     - All of your roles must have this permission attached to it via an IAM policy.

--- a/oktaawscli/okta_auth_config.py
+++ b/oktaawscli/okta_auth_config.py
@@ -10,26 +10,24 @@ import validators
 
 class OktaAuthConfig():
     """ Config helper class """
-    def __init__(self, logger):
+    def __init__(self, config_path, logger):
         self.logger = logger
-        self.config_path = os.path.expanduser('~') + '/.okta-aws'
+        self.config_path = config_path
         self._value = RawConfigParser()
         self._value.read(self.config_path)
     
-    @staticmethod
-    def configure(logger):
+    def configure(self):
         value = RawConfigParser()
-        config_path = os.path.expanduser('~') + '/.okta-aws'
-        if os.path.exists(config_path):
-            value.read(config_path)
+        if os.path.exists(self.config_path):
+            value.read(self.config_path)
             print(f"You have preconfigured Okta profiles: {value.sections()}")
-            print(f"This command will append new profile to the existing {config_path} config file")
+            print(f"This command will append new profile to the existing {self.config_path} config file")
         else:
-            print(f"This command will create a new {config_path} config file")
+            print(f"This command will create a new {self.config_path} config file")
 
         confirm = input('Would you like to proceed? [y/n]: ')
         if confirm == 'y':
-            logger.info(f"Creating new {config_path} file")
+            self.logger.info(f"Creating new {self.config_path} file")
             okta_profile = input('Enter Okta profile name: ')
             if not okta_profile:
                 okta_profile = 'default'
@@ -49,11 +47,11 @@ class OktaAuthConfig():
                 value.set(okta_profile, 'app-link', app_link)
             value.set(okta_profile, 'duration', duration)
 
-            with open(config_path, 'w') as configfile:
+            with open(self.config_path, 'w') as configfile:
                 value.write(configfile)
 
-            print(f"Configuration {config_path} successfully updated. Now you can authenticate to Okta")
-            print(f"Execute 'okta-awscli -o {okta_profile} -p {profile} sts get-caller-identity' to authenticate and retrieve credentials")
+            print(f"Configuration {self.config_path} successfully updated. Now you can authenticate to Okta")
+            print(f"Execute 'okta-awscli -o {okta_profile} -p {profile} --config-file {self.config_path} sts get-caller-identity' to authenticate and retrieve credentials")
             sys.exit(0)
         else:
             sys.exit(0)
@@ -181,9 +179,5 @@ class OktaAuthConfig():
         with open(self.config_path, 'w+') as configfile:
             self._value.write(configfile)
 
-    @staticmethod
-    def get_okta_profiles():
-        value = RawConfigParser()
-        config_path = os.path.expanduser('~') + '/.okta-aws'
-        value.read(config_path)
-        return value.sections()
+    def get_okta_profiles(self):
+        return self._value.sections()

--- a/oktaawscli/version.py
+++ b/oktaawscli/version.py
@@ -1,2 +1,2 @@
 """ version string """
-__version__ = '0.5.5'
+__version__ = '0.6.0'


### PR DESCRIPTION
This change adds a command line option (`--config-file`) to specify a non-standard config file to use, while defaulting to `~/.okta-aws`. This could be particularly handy in instances where a user wants to have multiple config files for different directories/applications/etc.

This also adds some light error handling to give the user a helpful message if the config file (either specified in the args or the default) doesn't yet exist.