### PR TITLE
fix: TypeError when saml assertion is None

### DIFF
--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -150,8 +150,8 @@ Please contact you administrator in order to unlock the account!""")
         """ Returns the SAML assertion from HTML """
         assertion = self.get_simple_assertion(html) or self.get_mfa_assertion(html)
 
-        if not assertion:
-            self.logger.error("SAML assertion not valid: " + assertion)
+        if assertion is None:
+            self.logger.error("SAML assertion not valid")
             sys.exit(-1)
         return assertion
 


### PR DESCRIPTION
When no saml assertion method is found, a TypeError is raised which could be miss leading.

before
```
okta-awscli --debug
DEBUG - Setting MFA factor to OKTA
INFO - App Link set as: ****
INFO - Authenticating to: ****.okta.com
INFO - Authenticating as: ****
Enter password:
ERROR - No Extra Verification. Title was <title>****.</title>
Traceback (most recent call last):
  File "/opt/homebrew/bin/okta-awscli", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/opt/homebrew/Cellar/okta-awscli/0.5.5_2/libexec/lib/python3.12/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/okta-awscli/0.5.5_2/libexec/lib/python3.12/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/okta-awscli/0.5.5_2/libexec/lib/python3.12/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/okta-awscli/0.5.5_2/libexec/lib/python3.12/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/okta-awscli/0.5.5_2/libexec/lib/python3.12/site-packages/oktaawscli/okta_awscli.py", line 141, in main
    get_credentials(
  File "/opt/homebrew/Cellar/okta-awscli/0.5.5_2/libexec/lib/python3.12/site-packages/oktaawscli/okta_awscli.py", line 36, in get_credentials
    _, assertion = okta.get_assertion()
                   ^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/okta-awscli/0.5.5_2/libexec/lib/python3.12/site-packages/oktaawscli/okta_auth.py", line 170, in get_assertion
    assertion = self.get_saml_assertion(resp)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/okta-awscli/0.5.5_2/libexec/lib/python3.12/site-packages/oktaawscli/okta_auth.py", line 154, in get_saml_assertion
    self.logger.error("SAML assertion not valid: " + assertion)
                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
TypeError: can only concatenate str (not "NoneType") to str
```

the fix suppress the false positive exception
```
okta-awscli --debug
DEBUG - Setting MFA factor to OKTA
INFO - App Link set as: ****
INFO - Authenticating to: ****.okta.com
INFO - Authenticating as: ****
Enter password:
ERROR - No Extra Verification. Title was <title>****.</title>
ERROR - SAML assertion not valid
``` 